### PR TITLE
Change name of root module

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Omniauth Esia (OAuth2)
+# OmniAuth Esia (OAuth2)
 
 This is the unofficial OmniAuth strategy for authenticating via OAuth2 to [ESIA (GosUslugi)](https://esia.gosuslugi.ru). Read more [here](http://minsvyaz.ru/ru/activity/directions/13/)
 
@@ -34,7 +34,7 @@ gem 'omniauth-esia'
 ```ruby
 # config/initializers/omniauth.rb
 Rails.application.config.middleware.use OmniAuth::Builder do
-  provider :esia, ENV['ESIA_ID'], 
+  provider :esia, ENV['ESIA_ID'],
     scope:    'fullname email',
     key_path: "#{Rails.root}/config/keys/private.key",
     crt_path: "#{Rails.root}/config/keys/certificate.crt"
@@ -46,7 +46,7 @@ or in Your Rails application with Devise. See full instruction [here](https://gi
 ```ruby
 # config/initializers/devise.rb
 Devise.setup do |config|
-  config.omniauth :esia, ENV['ESIA_ID'], 
+  config.omniauth :esia, ENV['ESIA_ID'],
     scope:    'fullname email',
     key_path: "#{Rails.root}/config/keys/private.key",
     crt_path: "#{Rails.root}/config/keys/certificate.crt"

--- a/lib/omniauth/esia/version.rb
+++ b/lib/omniauth/esia/version.rb
@@ -1,4 +1,4 @@
-module Omniauth
+module OmniAuth
   module Esia
     VERSION = '0.1.0'
   end

--- a/lib/omniauth/strategies/esia.rb
+++ b/lib/omniauth/strategies/esia.rb
@@ -1,7 +1,7 @@
 require 'omniauth-oauth2'
 require 'base64'
 
-module Omniauth
+module OmniAuth
   module Strategies
     class Esia < OmniAuth::Strategies::OAuth2
 
@@ -56,9 +56,9 @@ module Omniauth
         code = request.params['code']
         client.auth_code.get_token(code,
           {
-            state: state, 
-            scope: options.scope, 
-            timestamp: timestamp, 
+            state: state,
+            scope: options.scope,
+            timestamp: timestamp,
             redirect_uri: callback_url,
             token_type: 'Bearer'
           }

--- a/omniauth-esia.gemspec
+++ b/omniauth-esia.gemspec
@@ -4,7 +4,7 @@ require 'omniauth/esia/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'omniauth-esia'
-  spec.version       = Omniauth::Esia::VERSION
+  spec.version       = OmniAuth::Esia::VERSION
   spec.authors       = ['Elsant']
   spec.email         = ['elsant@nextmail.ru']
 

--- a/spec/omniauth/strategies/esia_spec.rb
+++ b/spec/omniauth/strategies/esia_spec.rb
@@ -1,18 +1,18 @@
 require 'spec_helper'
 
-RSpec.describe Omniauth::Strategies::Esia, :type => :strategy do
+RSpec.describe OmniAuth::Strategies::Esia, :type => :strategy do
 
   let(:request) { double('Request', :params => {}, :cookies => {}, :env => {}) }
 
   subject do
     args = ['client_id', @options || {}].compact
-    Omniauth::Strategies::Esia.new(*args).tap do |strategy|
+    OmniAuth::Strategies::Esia.new(*args).tap do |strategy|
       allow(strategy).to receive(:request) { request }
     end
   end
 
   it 'has a version number' do
-    expect(Omniauth::Esia::VERSION).not_to be nil
+    expect(OmniAuth::Esia::VERSION).not_to be nil
   end
 
   describe 'client options' do


### PR DESCRIPTION
The root module of strategy is called `Ominauth`, while the module of original oauth gem is called `OmniAuth`, so builder can't find the definition of strategy on initalization.
This fix changes name of root module and fixes the problem.